### PR TITLE
Various fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,18 +154,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -424,7 +424,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hb"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_approx_eq",
  "clap",
@@ -820,18 +820,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1079,9 +1079,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "hb"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Mark Pritchard <mpritcha@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-clap = "4.4.11"
+clap = "4.4.12"
 env_logger = "0.10.1"
 hdrhistogram = "7.5.4"
 indicatif = "0.17.7"

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ At the moment the only platform supported is Linux. Future releases will include
 
 #### Linux, static build, x86_64
 
-This uses a [Docker container](https://github.com/emk/rust-musl-builder) to build a statically linked binary that can be run on any reasonable x86_64 environment.
+This uses a [Docker container](https://github.com/clux/muslrust/) to build a statically linked binary that can be run on any reasonable x86_64 environment.
 
 ```
-alias rust-musl-builder='docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder'
-rust-musl-builder cargo build --release
+docker pull clux/muslrust:stable
+docker run -v $PWD:/volume --rm -t clux/muslrust:stable cargo build --release
 ```
 
 #### Compiling locally

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 use std::collections::HashMap;
+use std::env;
 use std::error::Error;
 use std::time::{Duration, Instant};
 
@@ -20,11 +21,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     // Parse the command line and read in the set of URLs we use to test
+    let args: Vec<String> = env::args().collect();
     let LoadTestContext {
         config,
         urls,
         payloads,
-    } = config::Config::from_cmdline()?;
+    } = config::Config::from_cmdline(args)?;
 
     // When testing POST or PUT, the total number of distinct requests should be the size of payloads list
     let distinct_requests_count = match config.http_method {
@@ -41,7 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let result_summary = workers::run_test(
         config.http_method,
         config.concurrency,
-        &request_generator,
+        request_generator,
         urls,
         payloads,
     );


### PR DESCRIPTION
- Update musl build image as the old image is no longer maintained
- Fixes to clap command line parser
- Command-line argument parsing for url_prefix etc
- Concurrency was completely broken, now enabled correctly